### PR TITLE
Added character class support

### DIFF
--- a/src/lattice_solution.rs
+++ b/src/lattice_solution.rs
@@ -98,9 +98,9 @@ pub trait LatticeSolution : Sized {
         let mut steps = vec![];
 
         match (patt, text) {
-            (Patt::Any, Text::Lit(_)) =>
+            (Patt::Class(class), Text::Lit(c)) if class.matches(*c) =>
                 steps.push(ix.hit()),
-            (Patt::Lit(a), Text::Lit(b)) if a == b =>
+            (Patt::Lit(a), Text::Lit(b)) if *a == *b =>
                 steps.push(ix.hit()),
             _ =>
                 (),
@@ -114,7 +114,7 @@ pub trait LatticeSolution : Sized {
         }
 
         match patt {
-            Patt::Lit(_) | Patt::Any =>
+            Patt::Lit(_) | Patt::Class(_) =>
                 steps.push(ix.skip_patt()),
             Patt::GroupStart =>
                 steps.push(ix.start_group()),
@@ -234,12 +234,28 @@ pub mod tests {
         test_solve_for_test_case::<Sln>(TestCase::match_lit_2());
     }
 
+    pub fn test_solve_match_class_1<Sln: LatticeSolution>() {
+        test_solve_for_test_case::<Sln>(TestCase::match_class_1());
+    }
+
+    pub fn test_solve_match_class_2<Sln: LatticeSolution>() {
+        test_solve_for_test_case::<Sln>(TestCase::match_class_2());
+    }
+
+    pub fn test_solve_match_class_3<Sln: LatticeSolution>() {
+        test_solve_for_test_case::<Sln>(TestCase::match_class_3());
+    }
+
     pub fn test_solve_match_kleene_1<Sln: LatticeSolution>() {
         test_solve_for_test_case::<Sln>(TestCase::match_kleene_1());
     }
 
     pub fn test_solve_match_kleene_2<Sln: LatticeSolution>() {
         test_solve_for_test_case::<Sln>(TestCase::match_kleene_2());
+    }
+
+    pub fn test_solve_match_kleene_3<Sln: LatticeSolution>() {
+        test_solve_for_test_case::<Sln>(TestCase::match_kleene_3());
     }
 
     pub fn test_solve_fail_empty_1<Sln: LatticeSolution>() {
@@ -260,6 +276,10 @@ pub mod tests {
 
     pub fn test_solve_fail_lit_3<Sln: LatticeSolution>() {
         test_solve_for_test_case::<Sln>(TestCase::fail_lit_3());
+    }
+
+    pub fn test_solve_fail_class_1<Sln: LatticeSolution>() {
+        test_solve_for_test_case::<Sln>(TestCase::fail_class_1());
     }
 
     pub fn test_solve_fail_kleene_1<Sln: LatticeSolution>() {

--- a/src/map_solution.rs
+++ b/src/map_solution.rs
@@ -169,6 +169,21 @@ mod tests {
     }
 
     #[test]
+    fn test_solve_match_class_1() {
+        tests::test_solve_match_class_1::<MapSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_class_2() {
+        tests::test_solve_match_class_2::<MapSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_class_3() {
+        tests::test_solve_match_class_3::<MapSolution>();
+    }
+
+    #[test]
     fn test_solve_match_kleene_1() {
         tests::test_solve_match_kleene_1::<MapSolution>();
     }
@@ -176,6 +191,11 @@ mod tests {
     #[test]
     fn test_solve_match_kleene_2() {
         tests::test_solve_match_kleene_2::<MapSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_kleene_3() {
+        tests::test_solve_match_kleene_3::<MapSolution>();
     }
 
     #[test]
@@ -201,6 +221,11 @@ mod tests {
     #[test]
     fn test_solve_fail_lit_3() {
         tests::test_solve_fail_lit_3::<MapSolution>();
+    }
+
+    #[test]
+    fn test_solve_fail_class_1() {
+        tests::test_solve_fail_class_1::<MapSolution>();
     }
 
     #[test]

--- a/src/table_solution.rs
+++ b/src/table_solution.rs
@@ -58,7 +58,7 @@ impl Config {
 
         for (orig_ix, patt) in original.iter().enumerate() {
             match patt {
-                Patt::Lit(_) | Patt::Any | Patt::GroupStart | Patt::GroupEnd | Patt::End => {
+                Patt::Lit(_) | Patt::Class(_) | Patt::GroupStart | Patt::GroupEnd | Patt::End => {
                     for _ in 0..=kleene_depth {
                         expanded.push(patt.clone());
                         original_ix.push(orig_ix);
@@ -263,6 +263,21 @@ mod tests {
     }
 
     #[test]
+    fn test_solve_match_class_1() {
+        tests::test_solve_match_class_1::<TableSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_class_2() {
+        tests::test_solve_match_class_2::<TableSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_class_3() {
+        tests::test_solve_match_class_3::<TableSolution>();
+    }
+
+    #[test]
     fn test_solve_match_kleene_1() {
         tests::test_solve_match_kleene_1::<TableSolution>();
     }
@@ -270,6 +285,11 @@ mod tests {
     #[test]
     fn test_solve_match_kleene_2() {
         tests::test_solve_match_kleene_2::<TableSolution>();
+    }
+
+    #[test]
+    fn test_solve_match_kleene_3() {
+        tests::test_solve_match_kleene_3::<TableSolution>();
     }
 
     #[test]
@@ -292,11 +312,16 @@ mod tests {
         tests::test_solve_fail_lit_2::<TableSolution>();
     }
 
-
     #[test]
     fn test_solve_fail_lit_3() {
         tests::test_solve_fail_lit_3::<TableSolution>();
     }
+
+    #[test]
+    fn test_solve_fail_class_1() {
+        tests::test_solve_fail_class_1::<TableSolution>();
+    }
+
     #[test]
     fn test_solve_fail_kleene_1() {
         tests::test_solve_fail_kleene_1::<TableSolution>();


### PR DESCRIPTION
In theory fuzzy should now support all single character classes
that rust regex library supports, with the noticeable caveat that
several parts of the fuzzy code still assume ascii characters
when converting from bytes to chars.
