### PR TITLE
Replace naive stack-based solve function with heap-based state tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
 name = "fuzzy"
 version = "0.1.0"
 dependencies = [
+ "nonempty",
  "regex-syntax",
  "test-case",
  "thiserror",
@@ -551,6 +552,12 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeaf4ad7403de93e699c191202f017118df734d3850b01e13a3a8b2e6953d3c9"
 
 [[package]]
 name = "num_cpus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ publish = false # don't publish anywhere, for now
 [workspace.dependencies]
 fuzzy = { path = "fuzzy" }
 
+nonempty = "0.8.1"
 regex-syntax = "0.7.5"
 thiserror = "1.0.48"
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ current output does not display this.
 
 Practical uses of Fuzzy
 -----------------------
-**Note:** since these examples were written, we've added support for alternatives and
-minimum repetition bounds. We should update our examples appropriately.
+**Note: this section was written with an older version of our Cargo file, and an older
+version of fuzzy with less features. We need to update it appropriately.**
 
 The Fuzzy tool was originally inspired by a scenario where we had to deal with
 tens of thousands of generated code files which had been created from different

--- a/fuzzy/Cargo.toml
+++ b/fuzzy/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+nonempty.workspace = true
 regex-syntax.workspace = true
 thiserror.workspace = true
 

--- a/fuzzy/src/error.rs
+++ b/fuzzy/src/error.rs
@@ -1,6 +1,7 @@
 //! Provides the [`enum@Error`] type currently used by all fuzzy code.
 
 use thiserror::Error;
+use std::fmt::Debug;
 use std::io;
 
 #[derive(Debug, Error)]
@@ -13,10 +14,18 @@ pub enum Error {
     PatternUnsupported(String),
     #[error("PATTERN sets a regex bound that is too large for this architecture")]
     RegexBoundTooLarge,
-    #[error("Internal error: entered an infinite loop at {0} when matching PATTERN against TEXT")]
-    InfiniteLoop(String),
-    #[error("Internal error: blocked at {0} when matching PATTERN against TEXT")]
-    Blocked(String),
+    #[error("Gave up matching PATTERN against TEXT after {0} steps")]
+    ExceededMaxSteps(usize),
+    #[error("Internal error: node {0} is neiher working nor done after being processed")]
+    NoNodeProgress(String),
+    #[error("Internal error: could not find NodeType for non-end Ix {0}")]
+    NoNodeType(String),
+    #[error("Internal error: can only initialise node {0} once")]
+    CannotInitialiseNode(String),
+    #[error("Internal error: can only update node {0} if it is initialised and not done")]
+    CannotUpdateNode(String),
+    #[error("Internal error: cannot retrieve node field(s) '{0}' unless node is {1}")]
+    CannotGetNodeField(&'static str, &'static str),
     #[error("Internal error: final state does not contain all output information")]
     IncompleteFinalState,
 }

--- a/fuzzy/src/lattice_solution.rs
+++ b/fuzzy/src/lattice_solution.rs
@@ -3,6 +3,7 @@
 use crate::{ElementCore, Match, Problem, Solution, Step};
 use crate::flat_pattern::Flat;
 use crate::error::Error;
+use nonempty::{NonEmpty, nonempty};
 use std::fmt::Debug;
 
 /// A naive family of "recurse through a lattice" [`Solution`] implementations.
@@ -43,20 +44,21 @@ pub trait LatticeSolution : Sized  + Solution<Error> {
         let start_ix = conf.start();
         let end_ix = conf.end();
 
-        let start_lead = Next { cost: 0, next: start_ix, step: None };
-        let _ = Self::solve_ix(&conf, &mut state, end_ix, start_lead)?;
+        let _ = Self::solve_ix(&conf, &mut state)?;
 
-        let score = match state.get(start_ix) {
-            Node::Done(Done { score, .. }) => Ok(score),
-            _ => Err(Error::IncompleteFinalState),
-        }?;
+        let start_node = state.get(start_ix);
+        let score = start_node.done_info()
+            .map(|i| i.0)
+            .map_err(|_| Error::IncompleteFinalState)?;
 
         let mut trace = vec![];
         let mut from = start_ix;
-        while let Node::Done(done) = state.get(from) {
-            if from == end_ix { break; }
-            for step in done.step.iter() {
-                let (patt, text) = conf.get(from);
+        loop {
+            let node = state.get(from);
+            if !node.is_done() || from == end_ix { break; }
+            let (patt, text) = conf.get(from);
+            let (_, step_type, next) = node.done_info()?;
+            if let Some(step) =  step_type.step() {
                 let final_step = step.map(
                     |_| match patt {
                         Some(Flat::Lit(c))   => Match::Lit(*c),
@@ -70,7 +72,7 @@ pub trait LatticeSolution : Sized  + Solution<Error> {
                 );
                 trace.push(final_step);
             }
-            from = done.next;
+            from = next;
         }
         if from != end_ix {
             return Err(Error::IncompleteFinalState);
@@ -86,102 +88,90 @@ pub trait LatticeSolution : Sized  + Solution<Error> {
     fn solve_ix(
         conf: &Self::Conf,
         state: &mut Self::State,
-        end_ix: Self::Ix,
-        lead: Next<Self::Ix>,
-     ) -> Result<Done<Self::Ix>, Error> {
-        let Next { cost, step, next: ix } = lead; // the step's lead is our current ix
+     ) -> Result<(), Error> {
+        let start_ix = conf.start();
+        let end_ix = conf.end();
 
-        match state.get(ix) {
-            Node::Working =>
-                Err(Error::InfiniteLoop(format!("{:?}", ix))),
-            Node::Done(done) =>
-                Ok(Done { score: done.score + cost, next: ix, step }),
-            Node::Ready => {
-                state.set(ix, Node::Working);
+        let mut loop_state = LoopState::Down(Down {
+            parent: Default::default(),
+            current: start_ix,
+        });
 
-                let mut maybe_score = None;
-                let (patt, text) = conf.get(ix);
+        let mut loop_counter = 0;
 
-                match (patt, text) {
-                    (Some(Flat::Class(class)), Some(c)) if class.matches(*c) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.hit(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    (Some(Flat::Lit(a)), Some(b)) if *a == *b => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.hit(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    _ =>
-                        (),
+        loop {
+            loop_counter += 1;
+            if loop_counter >= 1000000000 { // TODO make this max configurable
+                return Err(Error::ExceededMaxSteps(loop_counter));
+            }
+            let new_parent = match &loop_state {
+                LoopState::Down(down) if state.get(down.current).is_ready() => {
+                    let (flat, text) = conf.get(down.current);
+                    let opt_node_type = NodeType::get(flat, text, &down.current);
+                    let node_state = state.get_mut(down.current);
+                    node_state.initialise(end_ix, down.parent, down.current, opt_node_type)?;
+                    down.parent
                 }
-
-                match text {
-                    Some(_) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.skip_text(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    None =>
-                        (),
+                LoopState::Down(down) => down.parent,
+                LoopState::Back(back) => {
+                    let new_child = back.child;
+                    let (new_score, _, _) = state.get(new_child).done_info()?;
+                    let node_state = state.get_mut(back.current);
+                    let new_parent = node_state.update(new_child, back.current, new_score)?;
+                    new_parent
                 }
+            };
 
-                match patt {
-                    Some(Flat::Lit(_) | Flat::Class(_)) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.skip_patt(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::GroupStart) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.start_group(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::GroupEnd) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.stop_group(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::AlternativeLeft(off)) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.start_left(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.start_right(ix, *off))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::AlternativeRight(off)) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.pass_right(ix, *off))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::RepetitionEnd(off)) if ix.can_restart() => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.restart_repetition(ix, *off))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::RepetitionEnd(_)) => { // cannot restart
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.end_repetition(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    },
-                    Some(Flat::RepetitionStart(off)) => {
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.start_repetition(ix))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                        let outcome = Self::solve_ix(conf, state, end_ix, conf.pass_repetition(ix, *off))?;
-                        maybe_score = Self::update(maybe_score, outcome);
-                    }
-                    None =>
-                        (),
-                }
-
-                let score = match maybe_score {
-                    Some(score) => score,
-                    None if ix == end_ix =>
-                        Done { score: 0, next: end_ix, step: None },
-                    None =>
-                        return Err(Error::Blocked(format!("{:?}", ix))),
-                };
-
-                state.set(ix, Node::Done(score));
-                Ok(Done { score: score.score + cost, next: ix, step })
+            let current_ix = loop_state.current();
+            let final_state = state.get(current_ix);
+            if current_ix == start_ix && final_state.is_done() {
+                break;
+            } else if final_state.is_done() {
+                loop_state = LoopState::Back(Back {
+                    current: new_parent,
+                    child: current_ix,
+                });
+            } else if final_state.is_working() {
+                let current_step_type = final_state.current_step_type()?;
+                let child = conf.step(current_ix, current_step_type);
+                loop_state = LoopState::Down(Down {
+                    parent: current_ix,
+                    current: child,
+                });
+            } else {
+                return Err(Error::NoNodeProgress(format!("{:?}", current_ix)));
             }
         }
-    }
 
-    fn update(current: Option<Done<Self::Ix>>, new: Done<Self::Ix>) -> Option<Done<Self::Ix>> {
-        Some(current.map_or(new, |c| Done::optimal(c, new)))
+        Ok(())
     }
+}
+
+#[derive(Debug)]
+enum LoopState<Ix> {
+    Down(Down<Ix>),
+    Back(Back<Ix>),
+}
+
+impl <Ix: Copy + Clone> LoopState<Ix> {
+    fn current(&self) -> Ix {
+        match self {
+            LoopState::Down(down) => down.current,
+            LoopState::Back(back) => back.current,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Down<Ix> {
+    parent: Ix,
+    current: Ix,
+}
+
+#[derive(Debug)]
+struct Back<Ix> {
+    current: Ix,
+    child: Ix,
 }
 
 impl <Sln> Solution<Error> for Sln where
@@ -207,55 +197,207 @@ pub trait LatticeConfig<Ix> {
     fn start(&self) -> Ix;
     fn end(&self) -> Ix;
 
-    fn skip_text(&self, ix: Ix) -> Next<Ix>;
-    fn skip_patt(&self, ix: Ix) -> Next<Ix>;
-    fn hit(&self, ix: Ix) -> Next<Ix>;
-    fn start_group(&self, ix: Ix) -> Next<Ix>;
-    fn stop_group(&self, ix: Ix) -> Next<Ix>;
-    fn start_left(&self, ix: Ix) -> Next<Ix>;
-    fn start_right(&self, ix: Ix, off: usize) -> Next<Ix>;
-    fn pass_right(&self, ix: Ix, off: usize) -> Next<Ix>;
-    fn start_repetition(&self, ix: Ix) -> Next<Ix>;
-    fn end_repetition(&self, ix: Ix) -> Next<Ix>;
-    fn pass_repetition(&self, ix: Ix, off: usize) -> Next<Ix>;
-    fn restart_repetition(&self, ix: Ix, off: usize) -> Next<Ix>;
+    fn step(&self, ix: Ix, step_type: StepType) -> Ix;
 }
 
-pub trait LatticeState<Conf, Ix> {
+pub trait LatticeState<Conf, Ix: Clone> {
     fn new(conf: &Conf) -> Self;
-    fn get(&self, ix: Ix) -> Node<Ix>;
+    fn get(&self, ix: Ix) -> &Node<Ix>;
+    fn get_mut(&mut self, ix: Ix) -> &mut Node<Ix>;
     fn set(&mut self, ix: Ix, node: Node<Ix>);
 }
 
-pub trait LatticeIx<Conf> : Eq + PartialEq + Copy + Clone + Debug + Sized {
+// TODO Ix turns out to be a sizable struct, remove Copy and pass by reference where possible
+pub trait LatticeIx<Conf> : Eq + PartialEq + Copy + Clone + Debug + Sized + Default {
     fn can_restart(&self) -> bool;
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Node<Ix: Sized> {
-    Ready,
-    Working,
-    Done(Done<Ix>),
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Node<Ix: Clone + Sized> {
+    parent: Ix,
+    score: usize,
+    step_type: StepType,
+    next: Ix,
+    current: usize,
+    step_types: Vec<StepType>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct Done<Ix: Sized> {
-    pub score: usize,
-    pub next: Ix,
-    pub step: Option<Step<(),()>>,
+impl <Ix: Copy + Clone + Debug + Eq + Sized + Default> Node<Ix> {
+    pub fn new() -> Self {
+        Self {
+            current: 0,
+            parent: Default::default(),
+            score: 0,
+            step_type: StepType::Hit,
+            next: Default::default(),
+            step_types: vec![],
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.current == 0
+    }
+
+    fn is_working(&self) -> bool {
+        self.current > 0 && self.current <= self.step_types.len()
+    }
+
+    fn is_done(&self) -> bool {
+        self.current > self.step_types.len()
+    }
+
+    fn current_step_type(&self) -> Result<StepType, Error> {
+        if self.is_working() {
+            Ok(self.step_types[self.current - 1])
+        } else {
+            Err(Error::CannotGetNodeField("current_step_type", "working"))
+        }
+    }
+
+    fn done_info(&self) -> Result<(usize, StepType, Ix), Error> {
+        if self.is_done() {
+            Ok((self.score, self.step_type, self.next))
+        } else {
+            Err(Error::CannotGetNodeField("score/step_type/next", "done"))
+        }
+    }
+
+    fn initialise(&mut self, end_ix: Ix, parent_ix: Ix, ix: Ix, opt_node_type: Option<NodeType>) -> Result<(), Error>{
+        if self.is_ready() {
+            match opt_node_type {
+                Some(node_type) => {
+                    let step_types = Vec::from(node_type.step_types());
+                    self.parent = parent_ix;
+                    self.current += 1;
+                    self.step_types = step_types;
+                    Ok(())
+                }
+                None if ix == end_ix => { // end_ix: insert dummy done value
+                    self.parent = parent_ix;
+                    self.current += 1;
+                    Ok(())
+                }
+                None => {
+                    Err(Error::NoNodeType(format!("{:?}", ix)))
+                }
+            }
+        } else {
+            Err(Error::CannotInitialiseNode(format!("{:?}", ix)))
+        }
+    }
+
+    fn update(&mut self, new_child: Ix, ix: Ix, new_score: usize) -> Result<Ix, Error> {
+        if self.is_working() {
+            let parent_ix = self.parent;
+            let current_step_type = self.current_step_type()?;
+            let new_score = new_score + current_step_type.cost();
+            if self.current <= 1 || new_score < self.score {
+                self.step_type = current_step_type;
+                self.score = new_score;
+                self.next = new_child;
+                self.current += 1;
+            } else {
+                self.current += 1;
+            }
+            Ok(parent_ix)
+        } else {
+            Err(Error::CannotUpdateNode(format!("{:?}", ix)))
+        }
+   }
 }
 
-impl <Ix: Sized> Done<Ix> {
-    fn optimal(left: Self, right: Self) -> Self {
-        if left.score <= right.score { left } else { right }
+#[derive(Copy, Clone, Eq, Hash, PartialEq, Debug)]
+pub enum NodeType {
+    FinishedPattern,
+    FinishedText,
+    Hit,
+    NoHit,
+    StartGroup,
+    EndGroup,
+    AlternativeLeft(usize),
+    AlternativeRight(usize),
+    RepetitionStart(usize),
+    RepetitionRestart(usize),
+    RepetitionEnd,
+}
+
+impl NodeType {
+    fn get<Conf, Ix: LatticeIx<Conf>>(opt_flat: Option<&Flat>, opt_text: Option<&char>, ix: &Ix) -> Option<Self> {
+        // TODO this is really, really hard to follow for something conceptually simple. Can I make it nicer?
+        match opt_flat {
+            None if opt_text == None => None,
+            None => Some(NodeType::FinishedPattern),
+            Some(flat) => Some(match flat {
+                Flat::Lit(c) if opt_text == Some(c) => NodeType::Hit,
+                Flat::Lit(_) if opt_text == None => NodeType::FinishedText,
+                Flat::Lit(_) => NodeType::NoHit,
+                Flat::Class(class) if opt_text.map_or(false, |t| class.matches(*t)) => NodeType::Hit,
+                Flat::Class(_) if opt_text == None => NodeType::FinishedText,
+                Flat::Class(_) => NodeType::NoHit,
+                Flat::GroupStart => NodeType::StartGroup,
+                Flat::GroupEnd => NodeType::EndGroup,
+                Flat::AlternativeLeft(off) => NodeType::AlternativeLeft(*off),
+                Flat::AlternativeRight(off) => NodeType::AlternativeRight(*off),
+                Flat::RepetitionStart(off) => NodeType::RepetitionStart(*off),
+                Flat::RepetitionEnd(off) if ix.can_restart() => NodeType::RepetitionRestart(*off),
+                Flat::RepetitionEnd(_) => NodeType::RepetitionEnd,
+            })
+        }
+    }
+
+    fn step_types(&self) -> NonEmpty<StepType> {
+        use StepType::*;
+        match self {
+            Self::FinishedPattern => nonempty![SkipText],
+            Self::FinishedText => nonempty![SkipPattern],
+            Self::Hit => nonempty![Hit, SkipPattern, SkipText],
+            Self::NoHit => nonempty![SkipPattern, SkipText],
+            Self::StartGroup => nonempty![StartGroup],
+            Self::EndGroup => nonempty![EndGroup],
+            Self::AlternativeLeft(off) => nonempty![StartLeft, StartRight(*off)],
+            Self::AlternativeRight(off) => nonempty![PassRight(*off)],
+            Self::RepetitionStart(off) => nonempty![StartRepetition, PassRepetition(*off)],
+            Self::RepetitionRestart(off) => nonempty![RestartRepetition(*off)],
+            Self::RepetitionEnd => nonempty![EndRepetition],
+        }
     }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct Next<Ix> {
-    pub cost: usize,
-    pub next: Ix,
-    pub step: Option<Step<(),()>>,
+pub enum StepType {
+    SkipText,
+    SkipPattern,
+    Hit,
+    StartGroup,
+    EndGroup,
+    StartLeft,
+    StartRight(usize),
+    PassRight(usize),
+    StartRepetition,
+    PassRepetition(usize),
+    EndRepetition,
+    RestartRepetition(usize),
+}
+
+impl StepType {
+    fn cost(&self) -> usize {
+        match self {
+            Self::SkipPattern => 1,
+            Self::SkipText    => 1,
+            _                 => 0,
+        }
+    }
+
+    fn step(&self) -> Option<Step<(),()>> {
+        match self {
+            Self::Hit         => Some(Step::Hit((), ())),
+            Self::SkipPattern => Some(Step::SkipPattern(())),
+            Self::SkipText    => Some(Step::SkipText(())),
+            Self::StartGroup  => Some(Step::StartCapture),
+            Self::EndGroup    => Some(Step::StopCapture),
+            _                 => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/fuzzy/src/lib.rs
+++ b/fuzzy/src/lib.rs
@@ -354,9 +354,9 @@ pub mod test_cases {
                     Step::Hit(Match::Lit('a'), 'a'),
                     Step::Hit(Match::Lit('b'), 'b'),
                     // TODO handle valid possibility that the order of next three steps is changed
-                    Step::SkipText('k'),
                     Step::SkipPattern(Match::Lit('c')),
                     Step::SkipPattern(Match::Lit('d')),
+                    Step::SkipText('k'),
                     Step::Hit(Match::Lit('e'), 'e'),
                 ],
             }
@@ -398,8 +398,8 @@ pub mod test_cases {
                 score: 2,
                 trace: vec![
                     // TODO handle valid possibility that the order of next two steps is reversed
-                    Step::SkipText('a'),
                     Step::SkipPattern(patt_class("[^a]")),
+                    Step::SkipText('a'),
                 ],
             }
         }
@@ -544,8 +544,8 @@ pub mod test_cases {
                 problem: problem(vec![rep_bound(0, 1, lits("a"))], "aa"),
                 score: 1,
                 trace: vec![
-                    Step::SkipText('a'),
                     Step::Hit(Match::Lit('a'), 'a'),
+                    Step::SkipText('a'),
                 ],
             }
         }

--- a/fuzzy/src/map_solution.rs
+++ b/fuzzy/src/map_solution.rs
@@ -5,7 +5,7 @@
 
 use crate::{ElementCore, Match, Problem, Step};
 use crate::flat_pattern::{Flat, FlatPattern};
-use crate::lattice_solution::{LatticeConfig, LatticeIx, LatticeSolution, LatticeState, Next, Node};
+use crate::lattice_solution::{LatticeConfig, LatticeIx, LatticeSolution, LatticeState, Node, StepType};
 use std::collections::hash_map::HashMap;
 
 #[derive(Eq, PartialEq, Debug)]
@@ -56,82 +56,49 @@ impl LatticeConfig<Ix> for Config {
         Ix { pattern: self.pattern.len(), text: self.text.len(), rep_off: 0 }
     }
 
-    fn skip_text(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { text: ix.text + 1, rep_off: 0, ..ix };
-        Next { cost: 1, next, step: Some(Step::SkipText(())) }
+    fn step(&self, ix: Ix, step_type: StepType) -> Ix {
+        match step_type {
+            StepType::Hit =>
+                Ix { pattern: ix.pattern + 1, text: ix.text + 1, rep_off: 0, ..ix },
+            StepType::SkipText =>
+                Ix { text: ix.text + 1, rep_off: 0, ..ix },
+            StepType::SkipPattern | StepType::StartGroup | StepType::EndGroup | StepType::StartLeft =>
+                Ix { pattern: ix.pattern + 1, ..ix },
+            StepType::StartRight(off) =>
+                Ix { pattern: ix.pattern + off + 1, ..ix },
+            StepType::PassRight(off) =>
+                Ix { pattern: ix.pattern + off, ..ix },
+            StepType::StartRepetition =>
+                Ix { pattern: ix.pattern + 1, rep_off: ix.rep_off + 1, ..ix },
+            StepType::EndRepetition =>
+                Ix { pattern: ix.pattern + 1, rep_off: ix.rep_off - 1, ..ix },
+            StepType::PassRepetition(off) =>
+                Ix { pattern: ix.pattern + off + 1, ..ix},
+            StepType::RestartRepetition(off) =>
+                Ix { pattern: ix.pattern - off, ..ix },
+        }
     }
-
-    fn skip_patt(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, ..ix };
-        Next { cost: 1, next, step: Some(Step::SkipPattern(())) }
-    }
-
-    fn hit(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, text: ix.text + 1, rep_off: 0, ..ix };
-        Next { cost: 0, next, step: Some(Step::Hit((), ())) }
-    }
-
-    fn start_group(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, ..ix };
-        Next { cost: 0, next, step: Some(Step::StartCapture) }
-    }
-
-    fn stop_group(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, ..ix };
-        Next { cost: 0, next, step: Some(Step::StopCapture) }
-    }
-
-    fn start_left(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
-    fn start_right(&self, ix: Ix, off: usize) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + off + 1, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
-    fn pass_right(&self, ix: Ix, off: usize) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + off, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
-    fn start_repetition(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, rep_off: ix.rep_off + 1, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
-    fn end_repetition(&self, ix: Ix) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + 1, rep_off: ix.rep_off - 1, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
-    fn pass_repetition(&self, ix: Ix, off: usize) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern + off + 1, ..ix};
-        Next { cost: 0, next, step: None}
-    }
-
-    fn restart_repetition(&self, ix: Ix, off: usize) -> Next<Ix> {
-        let next = Ix { pattern: ix.pattern - off, ..ix };
-        Next { cost: 0, next, step: None }
-    }
-
 }
 
 pub struct State {
   nodes: HashMap<Ix, Node<Ix>>,
+  default: Node<Ix>,
 }
 
 impl LatticeState<Config, Ix> for State {
     fn new(_conf: &Config) -> Self {
-        State { nodes: HashMap::new() }
+        State { nodes: HashMap::new(), default: Node::new(), }
     }
 
-    fn get(&self, ix: Ix) -> Node<Ix> {
+    fn get(&self, ix: Ix) -> &Node<Ix> {
         match self.nodes.get(&ix) {
-            Some(node) => *node,
-            None => Node::Ready,
+            Some(node) => node,
+            None => &self.default,
         }
+    }
+
+    fn get_mut(&mut self, ix: Ix) -> &mut Node<Ix> {
+        self.nodes.entry(ix).or_insert(self.default.clone())
     }
 
     fn set(&mut self, ix: Ix, node: Node<Ix>) {
@@ -139,7 +106,7 @@ impl LatticeState<Config, Ix> for State {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Ix {
     /// The index into the [flattened `Problem::pattern`](crate::flat_pattern::FlatPattern).
     pub pattern: usize,


### PR DESCRIPTION
Our lattice solve function used to use the stack to store information about what our parent nodes were, how many of their children we had already traversed through, what the optimal score so far was, etc.

This was extremely convenient, but could not handle mid-sized use-cases.

I've had to (reluctantly) transfer all that information into our node table. I found it very tricky to satisfy rust's borrow checker while both reading and writing to that node table, so the solution I've ended up with may not be the cleanest possible solution. I might be able to revisit this in the future when I am more comfortable with rust.